### PR TITLE
Adding webpack script

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Run `npm i` to load all dependencies.
 
 ## Build
 
-Run `webpack` or `npm run bundle` to build the project. The build artifacts will be stored in the `public/bundle` directory.
+Run `npm run webpack` or `webpack` to build the project. The build artifacts will be stored in the `public/bundle` directory.
 
 ## Project Description
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # Airbnb Clone - A React project at DevMountain
 
+##Install
+
+Run `npm i` to load all dependencies.
+
 ## Build
 
-Run `webpack` to build the project. The build artifacts will be stored in the `public/bundle` directory.
+Run `webpack` or `npm run bundle` to build the project. The build artifacts will be stored in the `public/bundle` directory.
 
 ## Project Description
 

--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "dev": "webpack-dev-server --content-base public --inline --hot"
+    "dev": "webpack-dev-server --content-base public --inline --hot",
+    "bundle": "webpack --config=webpack.config.js --display-error-details"
   },
   "author": "",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "webpack-dev-server --content-base public --inline --hot",
-    "bundle": "webpack --config=webpack.config.js --display-error-details"
+    "webpack": "webpack --config=webpack.config.js --display-error-details"
   },
   "author": "",
   "license": "ISC",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,12 +22,7 @@ module.exports = {
         path: path.join(__dirname, "public/bundle/"),
         filename: "[name].js"
     },
-        resolveLoader: {
-                root: path.join(__dirname, "./node_modules")
-        },
         resolve: {
-                root: __dirname,
-                fallback: path.join(__dirname, "./node_modules"),
 		alias: alias 
         },
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,14 @@ var webpack = require('webpack');
 var path = require('path');
 var CommonsChunkPlugin = require("./node_modules/webpack/lib/optimize/CommonsChunkPlugin");
 
+var reactDomLibPath = path.join(__dirname, "./node_modules/react-dom/lib");
+var alias = {};
+["EventPluginHub", "EventConstants", "EventPluginUtils", "EventPropagators", 
+"SyntheticUIEvent", "CSSPropertyOperations", "ViewportMetrics"].forEach(function(filename){
+	alias["react/lib/"+filename] = path.join(__dirname, "./node_modules/react-dom/lib", filename)
+});
+
+
 module.exports = {
     entry: {
         main: "./src/App.js",
@@ -14,6 +22,15 @@ module.exports = {
         path: path.join(__dirname, "public/bundle/"),
         filename: "[name].js"
     },
+        resolveLoader: {
+                root: path.join(__dirname, "./node_modules")
+        },
+        resolve: {
+                root: __dirname,
+                fallback: path.join(__dirname, "./node_modules"),
+		alias: alias 
+        },
+
      plugins: [
         new CommonsChunkPlugin({
             filename: "commons.js",


### PR DESCRIPTION
Adding webpack script so that developers can run webpack by typing `npm run webpack` instead of having to install webpack globally and then run `webpack`

Also, updated README.md to reflect these changes.