### PR TITLE
Upgrading react-tap-event-plugin version to 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "jquery": "^3.1.0",
     "jwt-decode": "^2.1.0",
     "massive": "^2.5.0",
-    "material-ui": "^0.15.4",
+    "material-ui": "^0.16.4",
     "moment": "^2.14.1",
     "node-sass": "^3.8.0",
     "normalize.css": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "react-gmaps": "^1.5.0",
     "react-router": "^2.7.0",
     "react-slick": "^0.13.6",
-    "react-tap-event-plugin": "^1.0.0",
+    "react-tap-event-plugin": "^2.0.1",
     "request": "^2.74.0",
     "rheostat": "^2.0.0",
     "slick-carousel": "^1.6.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,13 +2,9 @@ var webpack = require('webpack');
 var path = require('path');
 var CommonsChunkPlugin = require("./node_modules/webpack/lib/optimize/CommonsChunkPlugin");
 
-var reactDomLibPath = path.join(__dirname, "./node_modules/react-dom/lib");
-var alias = {};
-["EventPluginHub", "EventConstants", "EventPluginUtils", "EventPropagators", 
-"SyntheticUIEvent", "CSSPropertyOperations", "ViewportMetrics"].forEach(function(filename){
-	alias["react/lib/"+filename] = path.join(__dirname, "./node_modules/react-dom/lib", filename)
-});
-
+var alias = {
+    "react/lib/CSSPropertyOperations": "react-dom/lib/CSSPropertyOperations"
+};
 
 module.exports = {
     entry: {
@@ -22,10 +18,9 @@ module.exports = {
         path: path.join(__dirname, "public/bundle/"),
         filename: "[name].js"
     },
-        resolve: {
-		alias: alias 
-        },
-
+    resolve: {
+        alias: alias 
+    },
      plugins: [
         new CommonsChunkPlugin({
             filename: "commons.js",


### PR DESCRIPTION
Upgrading react-tap-event-plugin version to 2.0.1 so that it works well with react 15.4. Also removing un-necessary alias that are not required after this upgrade. It still has one last remaining alias that is required for webpack to bundle smoothly.

Please don't merge if you think upgrading react-tap-event-plugin is not a good idea for this repo.